### PR TITLE
Use hscan_iter to fetch ALL processing queue timeouts.

### DIFF
--- a/pyrq/queues.py
+++ b/pyrq/queues.py
@@ -161,7 +161,7 @@ class Queue(object):
         self._wait_for_synced_slaves()
 
     def _get_sorted_processing_queues(self):
-        return sorted(self.redis.hscan(self.timeouts_hash_name)[1].items(), reverse=True)
+        return sorted(self.redis.hscan_iter(self.timeouts_hash_name), reverse=True)
 
     @property
     def processing_queue_name(self):

--- a/pyrq/unique_queues.py
+++ b/pyrq/unique_queues.py
@@ -168,7 +168,7 @@ class UniqueQueue(object):
         self._wait_for_synced_slaves()
 
     def _get_sorted_processing_queues(self):
-        return sorted(self.redis.hscan(self.timeouts_hash_name)[1].items(), reverse=True)
+        return sorted(self.redis.hscan_iter(self.timeouts_hash_name), reverse=True)
 
     @property
     def set_name(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='py-rq',
-    version='3.0.0',
+    version='3.0.1',
     packages=['pyrq'],
     url='https://github.com/heureka/py-rq',
     license='MIT',


### PR DESCRIPTION
 Not just the first 10. 

Also bump patchnumber.